### PR TITLE
Missed that there was a regex as well as inline parsing

### DIFF
--- a/src/Version/Stability.php
+++ b/src/Version/Stability.php
@@ -2,8 +2,6 @@
 
 namespace Version;
 
-use JsonSchema\Exception\InvalidArgumentException;
-
 class Stability
 {
 
@@ -109,7 +107,7 @@ class Stability
             case 'patch':
                 return 6;
             default:
-                throw new InvalidArgumentException( 'Invalid stability: ' . $stability );
+                throw new \InvalidArgumentException( 'Invalid stability: ' . $stability );
         }
     }
 }

--- a/src/Version/Stability.php
+++ b/src/Version/Stability.php
@@ -7,7 +7,7 @@ use JsonSchema\Exception\InvalidArgumentException;
 class Stability
 {
 
-    const REGEX = '[-|_|\.]{0,1}([R|r][C|c]|pl|a|alpha|[B|b][E|e][T|t][A|a]|b|B|patch|stable|p)\.{0,1}(\d*)';
+    const REGEX = '[-|_|\.]{0,1}([R|r][C|c]|pl|a|alpha|[B|b][E|e][T|t][A|a]|b|B|patch|stable|p|[D|d][E|e][V|v]|[D|d])\.{0,1}(\d*)';
 
     /**
      * @var string

--- a/src/Version/Version.php
+++ b/src/Version/Version.php
@@ -208,8 +208,8 @@ class Version
             $version =
                 $this->major . '.' .
                 $this->minor . '.' .
-                $this->revision . '.' .
-                (int)$this->micro;
+                $this->revision;
+                if($this->micro !== null) $version .= '.' . (int)$this->micro;
         } else {
             $version = $this->major;
             if ($this->minor) $version .= '-' . $this->minor;


### PR DESCRIPTION
Sorry missed that the parsing of strings is done both inline and as a regex, have modified tit to allow Dev.

Found a few other issues, fixed an exception callout and the micro version number should not be displayed if it is null (ie not 0+) as the fourth level is actually not semantic version compatible.
